### PR TITLE
Disabled credentials in redsocks.conf when they are empty

### DIFF
--- a/assets/entry_point.sh
+++ b/assets/entry_point.sh
@@ -51,8 +51,8 @@ EOF
 
     if test "$type" == "socks5"
     then 
-        echo "login = ${SOCKS_LOGIN};" >> /app/redsocks.conf
-        echo "password = ${SOCKS_PASSWORD};" >> /app/redsocks.conf
+        test -z "${SOCKS_LOGIN}" || echo "login = ${SOCKS_LOGIN};" >> /app/redsocks.conf
+        test -z "${SOCKS_PASSWORD}" || echo "password = ${SOCKS_PASSWORD};" >> /app/redsocks.conf
     fi
     
     echo "}" >> /app/redsocks.conf


### PR DESCRIPTION
### Description

A redsocks parsing error occurs when the SOCKS_LOGIN or SOCKS_PASSWORD are left empty, preventing byebyeproxy from booting properly. 


### Context

*Error*

```
file parsing error at line 30: assignment has only key but no value
file parsing error at line 30: unclosed section
```

*Cause*

redsocks configuration file entry
```
redsocks {
  type = socks5;
  ip = <REDACTED>;
  port = 3128;
  local_ip = 0.0.0.0;
  local_port = 22347;  
login = ;
password = ;
}
```


*`.byebyeproxy` configuration file*
```bash
#!/usr/bin/env bash
# Configuration file for byebyeproxy

# HTTP proxy full url
# PROXY_URL_HTTP=http://corporate_proxy.com:3128
PROXY_URL_HTTP=http://<REDACTED>:3128

# HTTPS proxy full URL
# PROXY_URL_HTTPS=http://corporate_proxy.com:3128
PROXY_URL_HTTPS=http://<REDACTED>:3128

# SOCKS
PROXY_SOCKS=http://<REDACTED>:3128
SOCKS_LOGIN=
SOCKS_PASSWORD=

# DNS IP only (format xxx.xxx.xxx.xxx)
# Port 53 is used. Do not specify it
# DNS_IP=corporate_dns_ip
DNS_IP=<REDACTED>
```

